### PR TITLE
fix: fix bug of inaccessible label field after typst 0.10.0

### DIFF
--- a/i-figured.typ
+++ b/i-figured.typ
@@ -72,8 +72,8 @@
   unnumbered-label: "-",
 ) = {
   if (
-    only-labeled and "label" not in it.fields()
-    or "label" in it.fields() and (
+    only-labeled and not it.has("label")
+    or it.has("label") and (
       str(it.label).starts-with(prefix)
       or str(it.label) == unnumbered-label
     )


### PR DESCRIPTION
This bug is only because the label is no longer shown in it.fields() and needs to be replaced with it.has("label").

PS: you can update the README example, which is still 0.2.0.

https://discord.com/channels/1054443721975922748/1088371919725793360/1181909961400385616