### PR TITLE
make reset-counters work for custom headings

### DIFF
--- a/i-figured.typ
+++ b/i-figured.typ
@@ -1,6 +1,6 @@
 #let _prefix = "i-figured-"
 
-#let reset-counters(it, level: 1, extra-kinds: (), equations: true) = {
+#let reset-counters(it, level: 1, extra-kinds: (), equations: true, return-orig-heading: true) = {
   if it.level <= level {
     for kind in (image, table, raw) + extra-kinds {
       counter(figure.where(kind: _prefix + repr(kind))).update(0)
@@ -9,7 +9,9 @@
       counter(math.equation).update(0)
     }
   }
-  it
+  if return-orig-heading {
+    it
+  }
 }
 
 #let _typst-numbering = numbering


### PR DESCRIPTION
When using custom headings (e.g. with a page break before the heading) sometimes the page information is messed up.
To fix this I added an option `reset-counters`  to not return the original heading in the content but just the counter updates.

Mininal example usage with the fix:
```rust
// custom level 1 heading with pagebreak
#show heading.where(level: 1): it => [
  #pagebreak(weak: true) 
  #it.body
  #i-figured.reset-counters(it, return-orig-heading: false)
]
```